### PR TITLE
Bump dependencies and migrate javaparser API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ target
 __pycache__
 trash
 docker/jupyter/test*
+.devcontainer

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val scala3Version = "3.3.1"
+val scala3Version = "3.3.7"
 
 maintainer := "kborowski@virtuslab.com"
 
@@ -18,14 +18,14 @@ lazy val root = project
     version := "0.1.10-SNAPSHOT",
     scalaVersion := scala3Version,
     protocExecutable(),
-    dockerBaseImage := "openjdk:11",
+    dockerBaseImage := "eclipse-temurin:21",
     packageName := "scg-cli",
     Compile / discoveredMainClasses := Seq("org.virtuslab.semanticgraphs.analytics.cli.ScgCli"),
     scalacOptions ++= Seq("-new-syntax", "-rewrite"),
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
-    libraryDependencies += "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.12",
-    libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.9.0",
-    libraryDependencies += "info.picocli" % "picocli" % "4.7.0"
+    libraryDependencies += "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.20",
+    libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.11.8",
+    libraryDependencies += "info.picocli" % "picocli" % "4.7.7"
 ).aggregate(javaparser, parsercommons, commons, spark).dependsOn(javaparser, commons)
 
 lazy val javaparser = project.in(file("javaparser")).settings(
@@ -34,8 +34,8 @@ lazy val javaparser = project.in(file("javaparser")).settings(
   Compile / PB.targets := Seq(
     scalapb.gen() -> (Compile / sourceManaged).value
   ),
-  libraryDependencies += "com.github.javaparser" % "javaparser-core" % "3.24.0",
-  libraryDependencies += "com.github.javaparser" % "javaparser-symbol-solver-core" % "3.24.0"
+  libraryDependencies += "com.github.javaparser" % "javaparser-core" % "3.28.1",
+  libraryDependencies += "com.github.javaparser" % "javaparser-symbol-solver-core" % "3.28.1"
 ).dependsOn(parsercommons).aggregate(parsercommons)
 
 lazy val parsercommons = project.in(file("parsercommons")).settings(
@@ -44,17 +44,17 @@ lazy val parsercommons = project.in(file("parsercommons")).settings(
   Compile / PB.targets := Seq(
     scalapb.gen() -> (Compile / sourceManaged).value
   ),
-  libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.10",
-  libraryDependencies += "com.typesafe.scala-logging" % "scala-logging_3" % "3.9.4",
-  libraryDependencies += "com.typesafe" % "config" % "1.4.2",
-  libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "6.0.0.202111291000-r",
-  libraryDependencies += "com.lihaoyi" %% "upickle" % "3.1.2"
+  libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.32",
+  libraryDependencies += "com.typesafe.scala-logging" % "scala-logging_3" % "3.9.6",
+  libraryDependencies += "com.typesafe" % "config" % "1.4.8",
+  libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "7.6.0.202603022253-r",
+  libraryDependencies += "com.lihaoyi" %% "upickle" % "4.4.3"
 )
 
 lazy val spark = project.in(file("spark")).settings(
   scalaVersion := scala3Version,
-  libraryDependencies += "org.apache.spark" %% "spark-graphx" % "3.3.1" cross CrossVersion.for3Use2_13,
-  libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.3.1" cross CrossVersion.for3Use2_13,
+  libraryDependencies += "org.apache.spark" %% "spark-graphx" % "3.5.8" cross CrossVersion.for3Use2_13,
+  libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.5.8" cross CrossVersion.for3Use2_13,
   excludeDependencies += "org.scala-lang.modules" % "scala-collection-compat_2.13",
 ).dependsOn(commons)
 
@@ -64,9 +64,9 @@ lazy val commons = project.in(file("commons")).settings(
   Compile / PB.targets := Seq(
     scalapb.gen() -> (Compile / sourceManaged).value
   ),
-  libraryDependencies += "org.jgrapht" % "jgrapht-core" % "1.5.1",
-  libraryDependencies += "org.jgrapht" % "jgrapht-io" % "1.5.1",
-  libraryDependencies += "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.13",
-  libraryDependencies += "com.lihaoyi" %% "upickle" % "3.1.2",
-  libraryDependencies += "org.apache.commons" % "commons-compress" % "1.23.0"
+  libraryDependencies += "org.jgrapht" % "jgrapht-core" % "1.5.3",
+  libraryDependencies += "org.jgrapht" % "jgrapht-io" % "1.5.3",
+  libraryDependencies += "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.20",
+  libraryDependencies += "com.lihaoyi" %% "upickle" % "4.4.3",
+  libraryDependencies += "org.apache.commons" % "commons-compress" % "1.28.0"
 )

--- a/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/JavaParserWithCaches.scala
+++ b/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/JavaParserWithCaches.scala
@@ -2,7 +2,8 @@ package com.virtuslab.semanticgraphs.javaparser
 
 import com.github.javaparser.{JavaParser, ParserConfiguration}
 import com.github.javaparser.ast.CompilationUnit
-import com.github.javaparser.symbolsolver.cache.{Cache, GuavaCache}
+import com.github.javaparser.resolution.cache.Cache
+import com.github.javaparser.symbolsolver.cache.GuavaCache
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver
 import com.github.javaparser.ParseStart.COMPILATION_UNIT
 import com.github.javaparser.Providers.provider

--- a/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/extractor/utils/DeclarationUtils.scala
+++ b/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/extractor/utils/DeclarationUtils.scala
@@ -469,7 +469,7 @@ extension (methodLike: MethodLikeDeclaration)(using
             case _                          => None
           }).toSeq
           methodVisibleToInheritors <- resolvedReferenceType.allMethodsVisibleToInheritors
-          if methodVisibleToInheritors.toAst.toScala.exists(_.hasTheSameSignature(method))
+          if methodVisibleToInheritors.toAst.toScala.collect { case m: MethodDeclaration => m }.exists(_.hasTheSameSignature(method))
           to <- Try(methodVisibleToInheritors.getQualifiedSignature).withLogging().toOption
         } yield Edge(
           to = to,

--- a/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/DummyExternalDependenciesTypeSolver.scala
+++ b/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/DummyExternalDependenciesTypeSolver.scala
@@ -14,8 +14,9 @@ import com.github.javaparser.ast.expr.Expression
 import com.github.javaparser.resolution.{MethodUsage, SymbolResolver}
 import com.github.javaparser.resolution.declarations.*
 import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType}
-import com.github.javaparser.symbolsolver.logic.{AbstractTypeDeclaration, MethodResolutionCapability}
-import com.github.javaparser.symbolsolver.model.resolution.SymbolReference
+import com.github.javaparser.symbolsolver.logic.AbstractTypeDeclaration
+import com.github.javaparser.resolution.logic.MethodResolutionCapability
+import com.github.javaparser.resolution.model.SymbolReference
 import com.github.javaparser.symbolsolver.resolution.typesolvers.MemoryTypeSolver
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
 

--- a/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/EDMTSCompatibleSymbolSolver.scala
+++ b/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/EDMTSCompatibleSymbolSolver.scala
@@ -3,6 +3,7 @@ package com.virtuslab.semanticgraphs.javaparser.solver
 import com.github.javaparser.ast.`type`.Type
 import com.github.javaparser.ast.expr.Expression
 import com.github.javaparser.ast.Node
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
 import com.github.javaparser.resolution.types.ResolvedType
 import com.github.javaparser.resolution.SymbolResolver
 import com.github.javaparser.symbolsolver.JavaSymbolSolver
@@ -36,4 +37,6 @@ class EDMTSCompatibleSymbolSolver(
     javaSymbolSolver.toResolvedType(javaparserType, resultClass)
 
   def calculateType(expression: Expression): ResolvedType = javaSymbolSolver.calculateType(expression)
+
+  def toTypeDeclaration(node: Node): ResolvedReferenceTypeDeclaration = javaSymbolSolver.toTypeDeclaration(node)
 }

--- a/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/declaration/DummyMethodResolutionCapability.scala
+++ b/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/declaration/DummyMethodResolutionCapability.scala
@@ -2,8 +2,8 @@ package com.virtuslab.semanticgraphs.javaparser.solver.declaration
 
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration
 import com.github.javaparser.resolution.types.ResolvedType
-import com.github.javaparser.symbolsolver.logic.MethodResolutionCapability
-import com.github.javaparser.symbolsolver.model.resolution.SymbolReference
+import com.github.javaparser.resolution.logic.MethodResolutionCapability
+import com.github.javaparser.resolution.model.SymbolReference
 
 import java.util
 import java.util.{Optional, UUID}

--- a/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/declaration/DummyResolvedReferenceTypeDeclaration.scala
+++ b/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/declaration/DummyResolvedReferenceTypeDeclaration.scala
@@ -9,7 +9,7 @@ import com.virtuslab.semanticgraphs.javaparser.solver.declaration.{
 import com.virtuslab.semanticgraphs.javaparser.solver.TypeArgumentsResolutionCache
 
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
-import com.github.javaparser.symbolsolver.logic.MethodResolutionCapability
+import com.github.javaparser.resolution.logic.MethodResolutionCapability
 
 /**
   * Dummy declaration to mock references to classes in external dependencies.

--- a/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/declaration/DummyResolvedTypeParameterDeclaration.scala
+++ b/javaparser/src/main/scala/com/virtuslab/semanticgraphs/javaparser/solver/declaration/DummyResolvedTypeParameterDeclaration.scala
@@ -13,7 +13,7 @@ import com.github.javaparser.resolution.declarations.{
 }
 import com.github.javaparser.resolution.types.ResolvedReferenceType
 import com.github.javaparser.resolution.UnsolvedSymbolException
-import com.github.javaparser.symbolsolver.model.typesystem.ReferenceTypeImpl
+import com.github.javaparser.resolution.model.typesystem.ReferenceTypeImpl
 
 import java.util
 import java.util.{Optional, UUID}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.12.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.4")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.0")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")

--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.8")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.12"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.20"


### PR DESCRIPTION
Updates Scala (3.3.1 -> 3.3.7 LTS), sbt (1.9.3 -> 1.12.11), and all library/plugin dependencies to their latest stable versions. Switches Docker base image to eclipse-temurin:21 since the openjdk image is deprecated and JGit 7 requires Java 17+.

JavaParser 3.24 -> 3.28 moved Cache, MethodResolutionCapability, SymbolReference, and ReferenceTypeImpl from symbolsolver.* to resolution.*; updates the corresponding imports. SymbolResolver gained a toTypeDeclaration method, now implemented in EDMTSCompatibleSymbolSolver. toAst now returns Optional[? extends Node], so DeclarationUtils narrows to MethodDeclaration via collect.